### PR TITLE
Parameter Fire_now added to scheduler functions.

### DIFF
--- a/app/routes/bots/bots.py
+++ b/app/routes/bots/bots.py
@@ -471,7 +471,7 @@ def toggle_activation_bot(bot_id):
                     )), 400
 
                 try:
-                    scheduling_success = schedule_bot(bot, category)
+                    scheduling_success = schedule_bot(bot, category, fire_now=True)
                 
                     if scheduling_success:
                         bot.is_active = True

--- a/app/routes/categories/categories.py
+++ b/app/routes/categories/categories.py
@@ -1,5 +1,6 @@
 # routes.py
 import os
+from sched import scheduler
 import boto3
 from sqlalchemy import func
 from dotenv import load_dotenv
@@ -332,7 +333,7 @@ def toggle_category_activation(category_id):
                             bot_result['error'] = f"Validation errors: {bot_validation_errors}"
                             failure_count += 1
                         else:
-                            scheduling_success = schedule_bot(bot, category)
+                            scheduling_success = schedule_bot(bot, category, fire_now=True)
                             if scheduling_success:
                                 bot.is_active = True
                                 bot.status = 'IDLE'

--- a/app/routes/categories/categories.py
+++ b/app/routes/categories/categories.py
@@ -1,6 +1,5 @@
 # routes.py
 import os
-from sched import scheduler
 import boto3
 from sqlalchemy import func
 from dotenv import load_dotenv


### PR DESCRIPTION
Fixed an issue in the category activation toggle endpoint where bots were failing to schedule due to a missing required parameter. The following changes were made:

- Added the missing `fire_now` parameter to the schedule_bot function call in the category activation toggle endpoint
- Updated the function call to include `fire_now=True` to ensure bots start running shortly after activation
- This fixes the error: "schedule_bot() missing 1 required positional argument: 'fire_now'"

The change ensures proper bot scheduling when toggling category activation and allows bots to start running immediately after being activated.

Technical details:
- Modified the schedule_bot function call in categories.py
- Changed from: schedule_bot(bot, category)
- To: schedule_bot(bot, category, fire_now=True)